### PR TITLE
Issues/74 graceful failure - skip unsupported parameters

### DIFF
--- a/modules/lily-compiler/src/main/java/io/github/tomboyo/lily/compiler/icg/AstGenerator.java
+++ b/modules/lily-compiler/src/main/java/io/github/tomboyo/lily/compiler/icg/AstGenerator.java
@@ -27,7 +27,6 @@ public class AstGenerator {
   }
 
   private Stream<Ast> evaluate(OpenAPI openAPI) {
-    var result = evaluateComponents(openAPI);
     return Stream.of(evaluateComponents(openAPI), evaluatePaths(openAPI)).flatMap(identity());
   }
 

--- a/modules/lily-compiler/src/main/java/io/github/tomboyo/lily/compiler/icg/OasOperationToAst.java
+++ b/modules/lily-compiler/src/main/java/io/github/tomboyo/lily/compiler/icg/OasOperationToAst.java
@@ -67,6 +67,7 @@ public class OasOperationToAst {
                 parameter ->
                     OasParameterToAst.evaluateParameter(
                         basePackage, subordinatePackageName, parameter))
+            .flatMap(Optional::stream)
             .toList();
     var parameterAst = parametersAndAst.stream().flatMap(OasParameterToAst.ParameterAndAst::ast);
     var parameters =

--- a/modules/lily-compiler/src/main/java/io/github/tomboyo/lily/compiler/icg/OasParameterToAst.java
+++ b/modules/lily-compiler/src/main/java/io/github/tomboyo/lily/compiler/icg/OasParameterToAst.java
@@ -14,11 +14,27 @@ import io.github.tomboyo.lily.compiler.ast.ParameterLocation;
 import io.github.tomboyo.lily.compiler.ast.SimpleName;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.Parameter.StyleEnum;
+import java.util.Optional;
 import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OasParameterToAst {
 
-  public static ParameterAndAst evaluateParameter(
+  private static final Logger LOGGER = LoggerFactory.getLogger(OasParameterToAst.class);
+
+  public static Optional<ParameterAndAst> evaluateParameter(
+      PackageName basePackage, PackageName genRoot, Parameter parameter) {
+    // A parameter may be a schema object or a reference object.
+    if (parameter.getSchema() != null) {
+      return Optional.of(evaluateSchema(basePackage, genRoot, parameter));
+    } else {
+      LOGGER.warn("Skipping parameter in {}: not yet supported.", genRoot);
+      return Optional.empty();
+    }
+  }
+
+  private static ParameterAndAst evaluateSchema(
       PackageName basePackage, PackageName genRoot, Parameter parameter) {
     var parameterRefAndAst =
         OasSchemaToAst.evaluateInto(

--- a/modules/lily-compiler/src/test/java/io/github/tomboyo/lily/compiler/CandlepinApiTest.java
+++ b/modules/lily-compiler/src/test/java/io/github/tomboyo/lily/compiler/CandlepinApiTest.java
@@ -1,26 +1,23 @@
 package io.github.tomboyo.lily.compiler;
 
-import io.github.tomboyo.lily.compiler.LilyExtension.LilyTestSupport;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.net.URI;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class CandlepinApiTest {
 
   @Test
   void test(@TempDir Path temp) {
-    assertDoesNotThrow(() ->
-    LilyCompiler.compile(
-        URI.create("https://raw.githubusercontent.com/candlepin/candlepin/e332838213587b1903e1c6331eaeff5f4912ef7e/api/candlepin-api-spec.yaml"),
-        temp,
-        "com.example.candlepin.api",
-        true));
+    assertDoesNotThrow(
+        () ->
+            LilyCompiler.compile(
+                URI.create(
+                    "https://raw.githubusercontent.com/candlepin/candlepin/e332838213587b1903e1c6331eaeff5f4912ef7e/api/candlepin-api-spec.yaml"),
+                temp,
+                "com.example.candlepin.api",
+                true));
   }
-
 }

--- a/modules/lily-compiler/src/test/java/io/github/tomboyo/lily/compiler/CandlepinApiTest.java
+++ b/modules/lily-compiler/src/test/java/io/github/tomboyo/lily/compiler/CandlepinApiTest.java
@@ -4,11 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.net.URI;
 import java.nio.file.Path;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class CandlepinApiTest {
-
+/** Compiles an open-source OpenAPI document for a real system to help unearth bugs. */
+@Disabled("Will not pass until '#74 - Graceful Failure' is finished.")
+class CandlepinApiTest {
   @Test
   void test(@TempDir Path temp) {
     assertDoesNotThrow(

--- a/modules/lily-compiler/src/test/java/io/github/tomboyo/lily/compiler/CandlepinApiTest.java
+++ b/modules/lily-compiler/src/test/java/io/github/tomboyo/lily/compiler/CandlepinApiTest.java
@@ -1,0 +1,26 @@
+package io.github.tomboyo.lily.compiler;
+
+import io.github.tomboyo.lily.compiler.LilyExtension.LilyTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URI;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class CandlepinApiTest {
+
+  @Test
+  void test(@TempDir Path temp) {
+    assertDoesNotThrow(() ->
+    LilyCompiler.compile(
+        URI.create("https://raw.githubusercontent.com/candlepin/candlepin/e332838213587b1903e1c6331eaeff5f4912ef7e/api/candlepin-api-spec.yaml"),
+        temp,
+        "com.example.candlepin.api",
+        true));
+  }
+
+}

--- a/modules/lily-compiler/src/test/java/io/github/tomboyo/lily/compiler/feature/ParametersTest.java
+++ b/modules/lily-compiler/src/test/java/io/github/tomboyo/lily/compiler/feature/ParametersTest.java
@@ -1,17 +1,17 @@
 package io.github.tomboyo.lily.compiler.feature;
 
-import static io.github.tomboyo.lily.compiler.CompilerSupport.compileOas;
-import static io.github.tomboyo.lily.compiler.CompilerSupport.deleteGeneratedSources;
-import static io.github.tomboyo.lily.compiler.CompilerSupport.evaluate;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.github.tomboyo.lily.compiler.LilyExtension;
+import io.github.tomboyo.lily.compiler.LilyExtension.LilyTestSupport;
 import java.net.URI;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Operations expose setters by parameter location, since parameters are only distinct by name and
@@ -43,168 +43,200 @@ import org.junit.jupiter.api.Test;
  * }</pre>
  */
 public class ParametersTest {
-
-  @AfterAll
-  static void afterAll() throws Exception {
-    deleteGeneratedSources();
-  }
-
   @Nested
-  class PathParameters {
-    private static String packageName;
-
-    @BeforeAll
-    static void beforeAll() throws Exception {
-      packageName =
-          compileOas(
-              """
-              openapi: 3.0.2
-              paths:
-                /pets/{kennelId}/{petId}:
-                  get:
-                    operationId: getPetFromKennel
-                    parameters:
-                      - name: kennelId
-                        in: path
-                        required: true
-                        schema:
-                          type: string
-                      - name: petId
-                        in: path
-                        required: true
-                        schema:
-                          type: string
-              """);
-    }
-
-    @Test
-    void path() {
-      var actual =
-          evaluate(
-              """
-              return %s.Api.newBuilder()
-                .uri("https://example.com/")
-                .build()
-                .everyOperation()
-                .getPetFromKennel()
-                .path(path ->
-                    path.kennelId("kennelId")
-                        .petId("petId"))
-                .httpRequest()
-                .uri();
-              """
-                  .formatted(packageName),
-              URI.class);
-      assertThat(
-          "Named path parameters are bound by the path method",
-          actual,
-          is(URI.create("https://example.com/pets/kennelId/petId")));
-    }
-
-    @Test
-    void pathString() {
-      var actual =
-          evaluate(
-              """
-              return %s.Api.newBuilder()
-                .uri("https://example.com/")
-                .build()
-                .everyOperation()
-                .getPetFromKennel()
-                .path(path ->
-                    path.kennelId("kennelId")
-                        .petId("petId"))
-                .pathString();
-              """
-                  .formatted(packageName),
-              String.class);
-      assertEquals(
-          "pets/kennelId/petId",
-          actual,
-          "pathString() returns the interpolated path part of the configured operation");
-    }
-  }
-
-  @Nested
-  class QueryParameters {
-    private static String packageName;
-
-    @BeforeAll
-    static void beforeAll() throws Exception {
-      packageName =
-          compileOas(
-              """
-              openapi: 3.0.2
-              paths:
-                /pets:
-                  get:
-                    operationId: listPets
-                    parameters:
-                      - name: limit
-                        in: query
-                        schema:
-                          type: integer
-                          format: int32
-                        # Path parameters are simple by default
-                        # style: simple
-                      - name: include
-                        in: query
-                        schema:
-                          type: array
-                          items:
+  class WhenSchemaObject {
+    @Nested
+    @ExtendWith(LilyExtension.class)
+    class WhenInPath {
+      @BeforeAll
+      static void beforeAll(LilyTestSupport support) throws Exception {
+        support.compileOas(
+            """
+                openapi: 3.0.2
+                paths:
+                  /pets/{kennelId}/{petId}:
+                    get:
+                      operationId: getPetFromKennel
+                      parameters:
+                        - name: kennelId
+                          in: path
+                          required: true
+                          schema:
                             type: string
-                        # Query parameters are form-explode by default
-                        # style: form
-                        # explode: true
-              """);
+                        - name: petId
+                          in: path
+                          required: true
+                          schema:
+                            type: string
+                """);
+      }
+
+      @Test
+      void path(LilyTestSupport support) {
+        var actual =
+            support.evaluate(
+                """
+                    return {{package}}.Api.newBuilder()
+                      .uri("https://example.com/")
+                      .build()
+                      .everyOperation()
+                      .getPetFromKennel()
+                      .path(path ->
+                          path.kennelId("kennelId")
+                              .petId("petId"))
+                      .httpRequest()
+                      .uri();
+                    """,
+                URI.class);
+        assertThat(
+            "Named path parameters are bound by the path method",
+            actual,
+            is(URI.create("https://example.com/pets/kennelId/petId")));
+      }
+
+      @Test
+      void pathString(LilyTestSupport support) {
+        var actual =
+            support.evaluate(
+                """
+                    return {{package}}.Api.newBuilder()
+                      .uri("https://example.com/")
+                      .build()
+                      .everyOperation()
+                      .getPetFromKennel()
+                      .path(path ->
+                          path.kennelId("kennelId")
+                              .petId("petId"))
+                      .pathString();
+                    """,
+                String.class);
+        assertEquals(
+            "pets/kennelId/petId",
+            actual,
+            "pathString() returns the interpolated path part of the configured operation");
+      }
     }
 
-    @Test
-    void query() {
-      var actual =
-          evaluate(
-              """
-              return %s.Api.newBuilder()
-                .uri("https://example.com/")
-                .build()
-                .everyOperation()
-                .listPets()
-                .query(query -> query
-                    .limit(5)
-                    .include(java.util.List.of("name", "age")))
-                .httpRequest()
-                .uri();
-              """
-                  .formatted(packageName),
-              URI.class);
-      assertThat(
-          "Query parameters are bound by the query method",
-          actual,
-          is(URI.create("https://example.com/pets?include=name&include=age&limit=5")));
-    }
+    @Nested
+    @ExtendWith(LilyExtension.class)
+    class WhenInQuery {
+      private static String packageName;
 
-    @Test
-    void queryString() {
-      var actual =
-          evaluate(
-              """
-          return %s.Api.newBuilder()
-            .uri("https://example.com/")
-            .build()
-            .everyOperation()
-            .listPets()
-            .query(query -> query
-                .limit(5)
-                .include(java.util.List.of("name", "age")))
-            .queryString();
+      @BeforeAll
+      static void beforeAll(LilyTestSupport support) throws Exception {
+        support.compileOas(
+            """
+                openapi: 3.0.2
+                paths:
+                  /pets:
+                    get:
+                      operationId: listPets
+                      parameters:
+                        - name: limit
+                          in: query
+                          schema:
+                            type: integer
+                            format: int32
+                          # Path parameters are simple by default
+                          # style: simple
+                        - name: include
+                          in: query
+                          schema:
+                            type: array
+                            items:
+                              type: string
+                          # Query parameters are form-explode by default
+                          # style: form
+                          # explode: true
+                """);
+      }
+
+      @Test
+      void query(LilyTestSupport support) {
+        var actual =
+            support.evaluate(
+                """
+                    return {{package}}.Api.newBuilder()
+                      .uri("https://example.com/")
+                      .build()
+                      .everyOperation()
+                      .listPets()
+                      .query(query -> query
+                          .limit(5)
+                          .include(java.util.List.of("name", "age")))
+                      .httpRequest()
+                      .uri();
+                    """,
+                URI.class);
+        assertThat(
+            "Query parameters are bound by the query method",
+            actual,
+            is(URI.create("https://example.com/pets?include=name&include=age&limit=5")));
+      }
+
+      @Test
+      void queryString(LilyTestSupport support) {
+        var actual =
+            support.evaluate(
+                """
+                    return {{package}}.Api.newBuilder()
+                      .uri("https://example.com/")
+                      .build()
+                      .everyOperation()
+                      .listPets()
+                      .query(query -> query
+                          .limit(5)
+                          .include(java.util.List.of("name", "age")))
+                      .queryString();
+                    """,
+                String.class);
+
+        assertEquals(
+            "?include=name&include=age&limit=5",
+            actual,
+            "queryString() returns the interpolated query string of the configured operation");
+      }
+    }
+  }
+
+  @Nested
+  @ExtendWith(LilyExtension.class)
+  class WhenRefObject {
+    @BeforeAll
+    static void beforeAll(LilyTestSupport support) {
+      support.compileOas(
           """
-                  .formatted(packageName),
-              String.class);
+            openapi: 3.0.2
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  parameters:
+                    - $ref: "#/components/schemas/Foo"
+                    - name: limit
+                      in: query
+                      schema:
+                        type: integer
+                        format: int32
+            """);
+    }
 
-      assertEquals(
-          "?include=name&include=age&limit=5",
-          actual,
-          "queryString() returns the interpolated query string of the configured operation");
+    @Test
+    void refIsSkipped(LilyTestSupport support) {
+      assertDoesNotThrow(
+          () ->
+              support.evaluate(
+                  """
+            return {{package}}.Api.newBuilder()
+              .uri("https://example.com/")
+              .build()
+              .everyOperation()
+              .listPets()
+              .query(query -> query
+                  .limit(5));
+            """),
+          "Unsupported parameter specifications do not prevent evaluation of supported"
+              + " parameters.");
     }
   }
 }


### PR DESCRIPTION
Adds better validation around parameter compilation, skipping parameters we cannot currently compile due to lack of features.

The CandlepinAPI test is there to help exercise out missing features, but is disabled in this MR so that it doesn't fail main-branch builds. Every bug it susses out is given a dedicate test.