### PR TITLE
Compile object schemas missing the type: object field

### DIFF
--- a/modules/lily-compiler/src/main/java/io/github/tomboyo/lily/compiler/icg/OasSchemaToAst.java
+++ b/modules/lily-compiler/src/main/java/io/github/tomboyo/lily/compiler/icg/OasSchemaToAst.java
@@ -74,7 +74,15 @@ public class OasSchemaToAst {
       PackageName currentPackage, SimpleName name, Schema<?> schema) {
     var type = schema.getType();
     if (type == null) {
-      return new Pair<>(toBasePackageClassReference(requireNonNull(schema.get$ref())), Stream.of());
+      var properties = schema.getProperties();
+      if (properties == null) {
+        return new Pair<>(
+            toBasePackageClassReference(requireNonNull(schema.get$ref())), Stream.of());
+      }
+
+      // If no discriminator, $ref, or type is specified, then it's *probably* an object if it has
+      // properties.
+      return evaluateObject(currentPackage, name, schema);
     }
 
     return switch (type) {

--- a/modules/lily-compiler/src/test/java/io/github/tomboyo/lily/compiler/feature/ComponentSchemaTest.java
+++ b/modules/lily-compiler/src/test/java/io/github/tomboyo/lily/compiler/feature/ComponentSchemaTest.java
@@ -1,0 +1,44 @@
+package io.github.tomboyo.lily.compiler.feature;
+
+import io.github.tomboyo.lily.compiler.LilyExtension;
+import io.github.tomboyo.lily.compiler.LilyExtension.LilyTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+public class ComponentSchemaTest {
+
+  @Nested
+  @ExtendWith(LilyExtension.class)
+  class WhenObjectSchemaWithoutType {
+    @BeforeAll
+    static void beforeAll(LilyTestSupport support) {
+      support.compileOas(
+          """
+              openapi: 3.0.2
+              components:
+                schemas:
+                  MySchema:
+                    properties:
+                      foo:
+                        type: string
+              """);
+    }
+
+    @Test
+    void test(LilyTestSupport support) {
+      Assertions.assertDoesNotThrow(
+          () ->
+              support.evaluate(
+                  """
+            return new {{package}}.MySchema("myFoo");
+            """),
+          """
+         If an object schema specification does not contain the type field, Lily infers that it is an object based on
+         the presence of the properties field
+         """);
+    }
+  }
+}


### PR DESCRIPTION
Type is not a required field, and OAS documents sometimes contain object schemas where type: object is assumed. We detect these by the presence or absence of a properties object.