### PR TITLE
Fix List<T> response body return types

### DIFF
--- a/modules/lily-compiler/src/main/java/io/github/tomboyo/lily/compiler/ast/Fqn.java
+++ b/modules/lily-compiler/src/main/java/io/github/tomboyo/lily/compiler/ast/Fqn.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -82,6 +83,19 @@ public record Fqn(PackageName packageName, SimpleName typeName, List<Fqn> typePa
    */
   public PackageName toPackage() {
     return packageName.resolve(typeName);
+  }
+
+  /**
+   * If this FQN describes a List, return an Optional of the List element's FQN, or else an empty
+   * optional.
+   */
+  public Optional<Fqn> listType() {
+    if (packageName.toString().equalsIgnoreCase("java.util")
+        && typeName.toString().equalsIgnoreCase("List")) {
+      return Optional.of(typeParameters.get(0));
+    } else {
+      return Optional.empty();
+    }
   }
 
   public static class Builder {

--- a/modules/lily-compiler/src/test/java/io/github/tomboyo/lily/compiler/CandlepinApiTest.java
+++ b/modules/lily-compiler/src/test/java/io/github/tomboyo/lily/compiler/CandlepinApiTest.java
@@ -4,12 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import io.github.tomboyo.lily.compiler.LilyExtension.LilyTestSupport;
 import java.net.URI;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /** Compiles an open-source OpenAPI document for a real system to help unearth bugs. */
-@Disabled("Will not pass until '#74 - Graceful Failure' is finished.")
 @ExtendWith(LilyExtension.class)
 class CandlepinApiTest {
   @Test


### PR DESCRIPTION
Because List<Foo>.class is not valid, we need to use an Arrays.asList(...) intermediary.